### PR TITLE
fixed login route url issue

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -8,8 +8,7 @@ const logInRoute= require('./logInRoutes')
 
 router.use('/api', apiRoutes);
 router.use('/cart', cartRoute);
-router.use('/', homeRoutes);
 router.use('/login', logInRoute);
-
+router.use('/', homeRoutes);
 
 module.exports = router;

--- a/controllers/logInRoutes.js
+++ b/controllers/logInRoutes.js
@@ -1,11 +1,13 @@
 const router = require('express').Router();
 
-router.get('/login',  (req, res) => {
+router.get('/',  (req, res) => {
+  console.log("loginroute")
    try{
      res.render('login')
    } catch(err) {
     res.status(500).json(err);
    }
 })
+
 
 module.exports = router;


### PR DESCRIPTION
login routes had an extra "/login" which made the url api/login/login, so I removed the extra login in the login-routes file and re-ordered the homeRoutes to the bottom of the list in index.js so it didn't take the /login as a parameter